### PR TITLE
Fixed compiler linking error with libm.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -264,7 +264,7 @@ def fnCompressCore(target, source, env):
 bldProcessing = Builder(action = fnProcessing) #, suffix = '.cpp', src_suffix = sketchExt)
 bldCompressCore = Builder(action = fnCompressCore)
 bldELF = Builder(action = AVR_BIN_PREFIX + 'gcc -mmcu=%s ' % MCU +
-                          '-Os -Wl,--gc-sections -lm -o $TARGET $SOURCES')
+                          '-Os -Wl,--gc-sections -lm -o $TARGET $SOURCES -lc')
 bldHEX = Builder(action = AVR_BIN_PREFIX + 'objcopy -O ihex -R .eeprom $SOURCES $TARGET')
 
 envArduino.Append(BUILDERS = {'Processing' : bldProcessing})


### PR DESCRIPTION
I ran into an error that seemed to be a problem with linking libm and libc. The error was as such:

> /usr/lib/gcc/avr/4.7.1/../../../../avr/lib/avr6/libc.a(inverse.o):../../../libm/fplib/inverse.S:50:(.text.avr-libc.fplib+0xc): relocation truncated to fit: R_AVR_13_PCREL against symbol `__divsf3' defined in .text section in /usr/lib/gcc/avr/4.7.1/avr6/libgcc.a(_div_sf.o)
> /usr/lib/gcc/avr/4.7.1/../../../../avr/lib/avr6/libc.a(square.o):../../../libm/fplib/square.S:43:(.text.avr-libc.fplib+0x4): relocation truncated to fit: R_AVR_13_PCREL against symbol`__mulsf3' defined in .text section in /usr/lib/gcc/avr/4.7.1/avr6/libgcc.a(_mul_sf.o)
> /usr/lib/gcc/avr/4.7.1/../../../../avr/lib/avr6/libc.a(fp_powsodd.o):../../../libm/fplib/fp_powsodd.S:59:(.text.avr-libc.fplib+0x10): relocation truncated to fit: R_AVR_13_PCREL against symbol `__mulsf3' defined in .text section in /usr/lib/gcc/avr/4.7.1/avr6/libgcc.a(_mul_sf.o)
> /usr/lib/gcc/avr/4.7.1/../../../../avr/lib/avr6/libc.a(fp_powsodd.o):../../../libm/fplib/fp_powsodd.S:69:(.text.avr-libc.fplib+0x20): relocation truncated to fit: R_AVR_13_PCREL against symbol`__mulsf3' defined in .text section in /usr/lib/gcc/avr/4.7.1/avr6/libgcc.a(_mul_sf.o)

I was able to resolve this issue by adding "-lc" to the compiler arguments for avr-gcc.
